### PR TITLE
Wrap FakeAsync returned to unit test in a Future.

### DIFF
--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -193,7 +193,7 @@ main() {
         });
 
         test('should add event before advancing time', () {
-          return new FakeAsync().run((async) {
+          return new Future(() => new FakeAsync().run((async) {
             var controller = new StreamController();
             var ret = controller.stream.first.then((_) {
               expect(async.elapsed, Duration.ZERO);
@@ -201,7 +201,7 @@ main() {
             controller.add(null);
             async.elapse(const Duration(minutes: 1));
             return ret;
-          });
+          }));
         });
 
         test('should increase negative duration timers to zero duration', () {


### PR DESCRIPTION
Hi Sean,

Mirroring the change [here](https://github.com/google/quiver-dart/commit/4607b54081c7dfe0f1de2e21a7a47bb2536cb6b8) which clears up a unit test timeout.

Thanks!
