### PR TITLE
Add stats reporting to FakeAsync

### DIFF
--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -86,6 +86,12 @@ abstract class FakeAsync {
   /// The [callback] is called with `this` as argument.
   run(callback(FakeAsync self));
 
+  /// Runs all remaining microtasks, including those scheduled as a result of
+  /// running them, until there are no more microtasks scheduled.
+  ///
+  /// Does not run timers.
+  void flushMicrotasks();
+
   /// The number of created periodic timers that have not been canceled.
   int get periodicTimerCount;
 
@@ -149,6 +155,11 @@ class _FakeAsync extends FakeAsync {
     return _zone.runGuarded(() => clock.withClock(fakeClock, () => callback(this)));
   }
   Zone _zone;
+
+  @override
+  void flushMicrotasks() {
+    _drainMicrotasks();
+  }
 
   @override
   int get periodicTimerCount =>

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -32,8 +32,8 @@ import 'package:clock/clock.dart' as clock;
 /// simulated using [elapseBlocking].
 abstract class FakeAsync {
 
-  /// [initialTime] controls the value of [clock.now] within [run] 
-  /// callbacks.  It defaults to the value of [clock.now] immediately before 
+  /// [initialTime] controls the value of [clock.now] within [run]
+  /// callbacks.  It defaults to the value of [clock.now] immediately before
   /// the [run] callback.
   factory FakeAsync({
       DateTime initialTime
@@ -85,6 +85,15 @@ abstract class FakeAsync {
   ///
   /// The [callback] is called with `this` as argument.
   run(callback(FakeAsync self));
+
+  /// The number of created periodic timers that have not been canceled.
+  int get periodicTimerCount;
+
+  /// The number of pending non periodic timers that have not been canceled.
+  int get nonPeriodicTimerCount;
+
+  /// The number of pending microtasks.
+  int get microtaskCount;
 }
 
 class _FakeAsync extends FakeAsync {
@@ -93,13 +102,14 @@ class _FakeAsync extends FakeAsync {
   Duration get elapsed => _elapsed;
   Duration _elapsingTo;
   DateTime _initialTime;
-  
+
   _FakeAsync({
     DateTime initialTime
-  }) 
+  })
       : super._(),
         _initialTime = initialTime {}
 
+  @override
   void elapse(Duration duration) {
     if (duration.inMicroseconds < 0) {
       throw new ArgumentError('Cannot call elapse with negative duration');
@@ -118,6 +128,7 @@ class _FakeAsync extends FakeAsync {
     _elapsingTo = null;
   }
 
+  @override
   void elapseBlocking(Duration duration) {
     if (duration.inMicroseconds < 0) {
       throw new ArgumentError('Cannot call elapse with negative duration');
@@ -128,6 +139,7 @@ class _FakeAsync extends FakeAsync {
     }
   }
 
+  @override
   run(callback(FakeAsync self)) {
     if (_zone == null) {
       _zone = Zone.current.fork(specification: _zoneSpec);
@@ -137,6 +149,17 @@ class _FakeAsync extends FakeAsync {
     return _zone.runGuarded(() => clock.withClock(fakeClock, () => callback(this)));
   }
   Zone _zone;
+
+  @override
+  int get periodicTimerCount =>
+      _timers.where((_FakeTimer timer) => timer._isPeriodic).length;
+
+  @override
+  int get nonPeriodicTimerCount =>
+      _timers.where((_FakeTimer timer) => !timer._isPeriodic).length;
+
+  @override
+  int get microtaskCount => _microtasks.length;
 
   ZoneSpecification get _zoneSpec => new ZoneSpecification(
       createTimer: (

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -341,6 +341,56 @@ main() {
 
     });
 
+    group('flushMicrotasks', () {
+      test('should flush a microtask', () {
+        new FakeAsync().run((async) {
+          bool microtaskRan = false;
+          new Future.microtask(() {
+            microtaskRan = true;
+          });
+          expect(microtaskRan, isFalse,
+              reason: 'should not flush until asked to');
+          async.flushMicrotasks();
+          expect(microtaskRan, isTrue);
+        });
+      });
+
+      test('should flush microtasks scheduled by microtasks in order', () {
+        new FakeAsync().run((async) {
+          final log = [];
+          new Future.microtask(() {
+            log.add(1);
+            new Future.microtask(() {
+              log.add(3);
+            });
+          });
+          new Future.microtask(() {
+            log.add(2);
+          });
+          expect(log, hasLength(0), reason: 'should not flush until asked to');
+          async.flushMicrotasks();
+          expect(log, [1, 2, 3]);
+        });
+      });
+
+      test('should not run timers', () {
+        new FakeAsync().run((async) {
+          final log = [];
+          new Future.microtask(() {
+            log.add(1);
+          });
+          new Future(() {
+            log.add(2);
+          });
+          new Timer.periodic(new Duration(seconds: 1), (_) {
+            log.add(2);
+          });
+          async.flushMicrotasks();
+          expect(log, [1]);
+        });
+      });
+    });
+
     group('stats', () {
       test('should report the number of pending microtasks', () {
         new FakeAsync().run((async) {
@@ -349,8 +399,7 @@ main() {
           expect(async.microtaskCount, 1);
           scheduleMicrotask(() => null);
           expect(async.microtaskCount, 2);
-          // flush microtasks
-          async.elapse(new Duration(milliseconds: 0));
+          async.flushMicrotasks();
           expect(async.microtaskCount, 0);
         });
       });

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -28,7 +28,7 @@ main() {
     test('should initialize elapsed to zero', () {
       expect(new FakeAsync().elapsed, Duration.ZERO);
     });
-    
+
     test('should have correct clock.now value', () {
       var initialTime = new DateTime(2014, 3, 6);
       new FakeAsync(initialTime: initialTime).run((async) {
@@ -339,6 +339,50 @@ main() {
 
       });
 
+    });
+
+    group('stats', () {
+      test('should report the number of pending microtasks', () {
+        new FakeAsync().run((async) {
+          expect(async.microtaskCount, 0);
+          scheduleMicrotask(() => null);
+          expect(async.microtaskCount, 1);
+          scheduleMicrotask(() => null);
+          expect(async.microtaskCount, 2);
+          // flush microtasks
+          async.elapse(new Duration(milliseconds: 0));
+          expect(async.microtaskCount, 0);
+        });
+      });
+
+      test('it should report the number of pending periodic timers', () {
+        new FakeAsync().run((async) {
+          expect(async.periodicTimerCount, 0);
+          Timer timer = new Timer.periodic(new Duration(minutes: 30),
+              (Timer timer) { });
+          expect(async.periodicTimerCount, 1);
+          new Timer.periodic(new Duration(minutes: 20), (Timer timer) { });
+          expect(async.periodicTimerCount, 2);
+          async.elapse(new Duration(minutes: 20));
+          expect(async.periodicTimerCount, 2);
+          timer.cancel();
+          expect(async.periodicTimerCount, 1);
+        });
+      });
+
+      test('it should report the number of pending non periodic timers', () {
+        new FakeAsync().run((async) {
+          expect(async.nonPeriodicTimerCount, 0);
+          Timer timer = new Timer(new Duration(minutes: 30), () { });
+          expect(async.nonPeriodicTimerCount, 1);
+          new Timer(new Duration(minutes: 20), () { });
+          expect(async.nonPeriodicTimerCount, 2);
+          async.elapse(new Duration(minutes: 25));
+          expect(async.nonPeriodicTimerCount, 1);
+          timer.cancel();
+          expect(async.nonPeriodicTimerCount, 0);
+        });
+      });
     });
 
   });


### PR DESCRIPTION
fixes #8 

sync from https://github.com/google/quiver-dart/pull/250

I had to use `async.elapse(new Duration(milliseconds: 0));` to flush the microtasks in tests because `flushMicrotasks()` is not exposed. Any particular reason for that ?

Nevermind, I have just seen issue #4, I'll add a separate commit for that
