### PR TITLE
Fix race condition in FakeAsync timeout test

### DIFF
--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -309,10 +309,10 @@ main() {
             StreamSubscription subscription;
             var periodic = new Stream.periodic(const Duration(minutes: 1),
                 (i) => i);
-            subscription = periodic.listen(events.add, cancelOnError: true);
+            subscription = periodic.listen(events.add);
             async.elapse(const Duration(minutes: 3));
-            subscription.cancel();
             expect(events, [0, 1, 2]);
+            subscription.cancel();
           });
 
         });
@@ -323,16 +323,15 @@ main() {
             var errors = [];
             var controller = new StreamController();
             var timed = controller.stream.timeout(const Duration(minutes: 2));
-            var subscription = timed.listen(events.add, onError: errors.add,
-                cancelOnError: true);
+            var subscription = timed.listen(events.add, onError: errors.add);
             controller.add(0);
             async.elapse(const Duration(minutes: 1));
             expect(events, [0]);
             async.elapse(const Duration(minutes: 1));
-            subscription.cancel();
             expect(errors, hasLength(1));
             expect(errors.first, new isInstanceOf<TimeoutException>());
-            return controller.close();
+            subscription.cancel();
+            controller.close();
           });
 
         });


### PR DESCRIPTION
Dart SDK commits 6255638 and 70c48b9 introduced changes to stream
subscription cancellation. This change eliminates the use of
cancelOnError in two tests where it was irrelevant to the tests in
question.
